### PR TITLE
Improve Firestore offline handling

### DIFF
--- a/firebaseConfig.js
+++ b/firebaseConfig.js
@@ -11,5 +11,10 @@ if (typeof firebase !== 'undefined') {
   };
   firebase.initializeApp(firebaseConfig);
   // Expose Firestore globally for easy access in app.js
-  window.db = firebase.firestore();
+  // Enable offline persistence so the app keeps working without internet
+  const db = firebase.firestore();
+  db.enablePersistence({ synchronizeTabs: true }).catch((err) => {
+    console.warn('Firestore persistence could not be enabled', err);
+  });
+  window.db = db;
 }

--- a/public/app.js
+++ b/public/app.js
@@ -158,7 +158,7 @@
 
 
   async function loadFromFirestore(){
-    if(!window.db) return;
+    if(!window.db || !navigator.onLine) return;
     setSyncStatus('Sincronizando...', true);
     try{
       const snap = await window.db.collection("animals").get();


### PR DESCRIPTION
## Summary
- enable Firestore persistence and expose shared instance
- skip Firestore load when offline to avoid failed connection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adfc0a1f2c832eb945d75ff22c898e