### PR TITLE
Prevent HTML responses from breaking JSON fetches

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -556,6 +556,12 @@
     setSyncStatus('Sincronizando...', true);
     try {
       const res = await fetch('/forecast');
+      if(!res.ok) throw new Error(`HTTP ${res.status}`);
+      const contentType = res.headers.get('content-type') || '';
+      if(!contentType.includes('application/json')){
+        const text = await res.text();
+        throw new Error(`Unexpected content-type: ${contentType} body: ${text.slice(0,100)}`);
+      }
       forecast = await res.json();
       renderPlanejamento();
       renderAlertas();
@@ -641,6 +647,12 @@
         headers:{'Content-Type':'application/json'},
         body: JSON.stringify(payload)
       });
+      if(!res.ok) throw new Error(`HTTP ${res.status}`);
+      const contentType = res.headers.get('content-type') || '';
+      if(!contentType.includes('application/json')){
+        const text = await res.text();
+        throw new Error(`Unexpected content-type: ${contentType} body: ${text.slice(0,100)}`);
+      }
       const data = await res.json();
       lastSync = data.timestamp;
       save('gado.lastSync', lastSync);

--- a/public/server.js
+++ b/public/server.js
@@ -7,9 +7,6 @@ const { generateForecast } = require('./mlPipeline');
 
 const app = express();
 app.use(express.json());
-// Serve static assets from the current directory so the frontend and API can
-// be hosted together when running the server locally.
-app.use(express.static(__dirname));
 
 const db = new sqlite3.Database('data.db');
 db.serialize(() => {
@@ -431,5 +428,10 @@ app.get('/forecast', (req, res) => {
   const result = generateForecast(animals, pesagens, despesas);
   res.json(result);
 });
+
+// After all API routes are defined, serve static assets so that API endpoints
+// are not intercepted by the static middleware (which would return HTML and
+// break JSON clients).
+app.use(express.static(__dirname));
 
 app.listen(3000, () => console.log('API running on port 3000'));


### PR DESCRIPTION
## Summary
- Ensure forecast and sync calls validate HTTP status and JSON content before parsing
- Serve static assets only after API routes so routes like `/forecast` are not intercepted

## Testing
- `npm test`
- `curl -i http://localhost:3000/forecast`
- `curl -i -X POST http://localhost:3000/sync -H 'Content-Type: application/json' -d '{"since":0,"animals":[],"pesagens":[]}'`


------
https://chatgpt.com/codex/tasks/task_e_68adfe3eeb90832e835099d6e9cacbdf